### PR TITLE
Share geometry pipeline layout across geometry passes

### DIFF
--- a/mjolnir/depth_buffer.odin
+++ b/mjolnir/depth_buffer.odin
@@ -25,33 +25,10 @@ depth_prepass_init :: proc(
 ) -> (
   res: vk.Result,
 ) {
-  push_constant_range := vk.PushConstantRange {
-    stageFlags = {.VERTEX},
-    size       = size_of(PushConstant),
+  self.pipeline_layout = warehouse.geometry_pipeline_layout
+  if self.pipeline_layout == 0 {
+    return .ERROR_INITIALIZATION_FAILED
   }
-  set_layouts := [?]vk.DescriptorSetLayout {
-    warehouse.camera_buffer_set_layout,
-    warehouse.textures_set_layout,
-    warehouse.bone_buffer_set_layout,
-    warehouse.material_buffer_set_layout,
-    warehouse.world_matrix_buffer_set_layout,
-    warehouse.node_data_buffer_set_layout,
-    warehouse.mesh_data_buffer_set_layout,
-    warehouse.vertex_skinning_buffer_set_layout,
-  }
-  pipeline_layout_info := vk.PipelineLayoutCreateInfo {
-    sType                  = .PIPELINE_LAYOUT_CREATE_INFO,
-    setLayoutCount         = len(set_layouts),
-    pSetLayouts            = raw_data(set_layouts[:]),
-    pushConstantRangeCount = 1,
-    pPushConstantRanges    = &push_constant_range,
-  }
-  vk.CreatePipelineLayout(
-    gpu_context.device,
-    &pipeline_layout_info,
-    nil,
-    &self.pipeline_layout,
-  ) or_return
   depth_prepass_build_pipeline(
     gpu_context,
     self,
@@ -67,8 +44,6 @@ depth_prepass_deinit :: proc(
 ) {
   vk.DestroyPipeline(gpu_context.device, self.pipeline, nil)
   self.pipeline = 0
-  vk.DestroyPipelineLayout(gpu_context.device, self.pipeline_layout, nil)
-  self.pipeline_layout = 0
 }
 
 depth_prepass_begin :: proc(

--- a/mjolnir/geometry_buffer.odin
+++ b/mjolnir/geometry_buffer.odin
@@ -23,32 +23,10 @@ gbuffer_init :: proc(
   warehouse: ^ResourceWarehouse,
 ) -> vk.Result {
   depth_format: vk.Format = .D32_SFLOAT
-  set_layouts := [?]vk.DescriptorSetLayout {
-    warehouse.camera_buffer_set_layout,
-    warehouse.textures_set_layout,
-    warehouse.bone_buffer_set_layout,
-    warehouse.material_buffer_set_layout,
-    warehouse.world_matrix_buffer_set_layout,
-    warehouse.node_data_buffer_set_layout,
-    warehouse.mesh_data_buffer_set_layout,
-    warehouse.vertex_skinning_buffer_set_layout,
+  self.pipeline_layout = warehouse.geometry_pipeline_layout
+  if self.pipeline_layout == 0 {
+    return .ERROR_INITIALIZATION_FAILED
   }
-  push_constant_range := vk.PushConstantRange {
-    stageFlags = {.VERTEX, .FRAGMENT},
-    size       = size_of(PushConstant),
-  }
-  vk.CreatePipelineLayout(
-    gpu_context.device,
-    &{
-      sType = .PIPELINE_LAYOUT_CREATE_INFO,
-      setLayoutCount = len(set_layouts),
-      pSetLayouts = raw_data(set_layouts[:]),
-      pushConstantRangeCount = 1,
-      pPushConstantRanges = &push_constant_range,
-    },
-    nil,
-    &self.pipeline_layout,
-  ) or_return
   log.info("About to build G-buffer pipelines...")
   vert_shader_code := #load("shader/gbuffer/vert.spv")
   vert_module := gpu.create_shader_module(
@@ -456,6 +434,4 @@ gbuffer_render :: proc(
 
 gbuffer_deinit :: proc(self: ^RendererGBuffer, gpu_context: ^gpu.GPUContext) {
   vk.DestroyPipeline(gpu_context.device, self.pipeline, nil)
-
-  vk.DestroyPipelineLayout(gpu_context.device, self.pipeline_layout, nil)
 }


### PR DESCRIPTION
## Summary
- add a shared geometry pipeline layout built from the engine's global descriptor set layouts
- reuse the shared pipeline layout across the shadow, depth prepass, g-buffer, and transparent renderers to avoid duplicate layout creation/destruction

## Testing
- `odin check .` *(fails: Qt xcb platform plugin not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b92b3fcc8330a6f66d825d95f15f