### PR TITLE
Refine light and emitter GPU updates

### DIFF
--- a/mjolnir/resources/emitter.odin
+++ b/mjolnir/resources/emitter.odin
@@ -1,6 +1,7 @@
 package resources
 
 import "../geometry"
+import "../gpu"
 
 EmitterData :: struct {
   initial_velocity:  [4]f32,
@@ -38,5 +39,60 @@ Emitter :: struct {
   texture_handle:    Handle,
   bounding_box:      geometry.Aabb,
   node_handle:       Handle,
-  is_dirty:          bool,
+}
+
+update_emitter_gpu_data :: proc(
+  manager: ^Manager,
+  handle: Handle,
+  node_index: u32,
+  visible: bool,
+) {
+  if handle.index >= MAX_EMITTERS {
+    return
+  }
+
+  emitter := get(manager.emitters, handle)
+  if emitter == nil {
+    return
+  }
+
+  gpu_data := EmitterData {
+    initial_velocity  = emitter.initial_velocity,
+    color_start       = emitter.color_start,
+    color_end         = emitter.color_end,
+    emission_rate     = emitter.emission_rate,
+    particle_lifetime = emitter.particle_lifetime,
+    position_spread   = emitter.position_spread,
+    velocity_spread   = emitter.velocity_spread,
+    size_start        = emitter.size_start,
+    size_end          = emitter.size_end,
+    weight            = emitter.weight,
+    weight_spread     = emitter.weight_spread,
+    texture_index     = emitter.texture_handle.index,
+    node_index        = node_index,
+    visible           = cast(b32)(visible && emitter.enabled != b32(false)),
+    aabb_min          = {
+      emitter.bounding_box.min.x,
+      emitter.bounding_box.min.y,
+      emitter.bounding_box.min.z,
+      0.0,
+    },
+    aabb_max          = {
+      emitter.bounding_box.max.x,
+      emitter.bounding_box.max.y,
+      emitter.bounding_box.max.z,
+      0.0,
+    },
+  }
+
+  current := gpu.staged_buffer_get(&manager.emitter_buffer, handle.index)
+  if current != nil {
+    gpu_data.time_accumulator = current.time_accumulator
+  }
+
+  gpu.staged_buffer_write(
+    &manager.emitter_buffer,
+    &gpu_data,
+    int(handle.index),
+  )
 }

--- a/mjolnir/resources/handles.odin
+++ b/mjolnir/resources/handles.odin
@@ -6,3 +6,4 @@ Texture2D_Handle :: Handle
 TextureCube_Handle :: Handle
 RenderTarget_Handle :: Handle
 Camera_Handle :: Handle
+Light_Handle :: Handle

--- a/mjolnir/resources/light.odin
+++ b/mjolnir/resources/light.odin
@@ -1,19 +1,79 @@
 package resources
 
+import "../gpu"
+
+LightKind :: enum u32 {
+  POINT,
+  DIRECTIONAL,
+  SPOT,
+}
+
+LightShadowResources :: struct {
+  render_target:       Handle,
+  cube_render_targets: [6]Handle,
+  camera:              Handle,
+  cube_cameras:        [6]Handle,
+  shadow_map:          Handle,
+}
+
 LightData :: struct {
-	color:        [4]f32, // RGB + intensity
-	radius:       f32,    // range for point/spot lights
-	angle_inner:  f32,    // inner cone angle for spot lights (cosine)
-	angle_outer:  f32,    // outer cone angle for spot lights (cosine)
-	type:         u32,    // LightType
-	node_index:   u32,    // index into world matrices buffer
-	shadow_map:   u32,    // texture index in bindless array
-	enabled:      b32,    // 0 = disabled, 1 = enabled
-	cast_shadow:  b32,    // 0 = no shadow, 1 = cast shadow
+  color:               [4]f32,
+  position:            [4]f32,
+  direction:           [4]f32,
+  radius:              f32,
+  angle:               f32,
+  intensity:           f32,
+  padding:             f32,
+  type:                u32,
+  shadow_map:          u32,
+  light_camera_index:  u32,
+  enabled:             b32,
+  cast_shadow:         b32,
+  cube_camera_indices: [6]u32,
 }
 
 Light :: struct {
-	data:         LightData,
-	node_handle:  Handle,     // Associated scene node for transform updates
-	is_dirty:     bool,       // Needs GPU sync
+  kind:        LightKind,
+  color:       [4]f32,
+  radius:      f32,
+  angle:       f32,
+  cast_shadow: bool,
+  enabled:     bool,
+  node_handle: Handle,
+  position:    [3]f32,
+  direction:   [3]f32,
+  shadow:      LightShadowResources,
+}
+
+update_light_gpu_data :: proc(manager: ^Manager, handle: Handle) {
+  if handle.index >= MAX_LIGHTS {
+    return
+  }
+  light := get(manager.lights, handle)
+  if light == nil {
+    return
+  }
+  gpu_data := LightData {
+    color               = light.color,
+    position            = [4]f32{light.position.x, light.position.y, light.position.z, 1.0},
+    direction           = [4]f32{light.direction.x, light.direction.y, light.direction.z, 0.0},
+    radius              = light.radius,
+    angle               = light.angle,
+    intensity           = light.color.w,
+    padding             = 0.0,
+    type                = cast(u32)light.kind,
+    shadow_map          = light.shadow.shadow_map.index,
+    light_camera_index  = light.shadow.camera.index,
+    enabled             = cast(b32)light.enabled,
+    cast_shadow         = cast(b32)light.cast_shadow,
+    cube_camera_indices = {},
+  }
+  for i in 0 ..< len(gpu_data.cube_camera_indices) {
+    gpu_data.cube_camera_indices[i] = light.shadow.cube_cameras[i].index
+  }
+  gpu.staged_buffer_write(
+    &manager.lights_buffer,
+    &gpu_data,
+    int(handle.index),
+  )
 }


### PR DESCRIPTION
## Summary
- add a resource helper to stage emitter GPU data directly and clear slots when handles are destroyed
- refresh world traversal to push light and emitter GPU updates when nodes move or change visibility
- remove frame-wide sync calls by letting the engine only update emitter counts before simulation

## Testing
- not run (odin missing in container)

------
https://chatgpt.com/codex/tasks/task_e_68d784cd072c8330b2c812f18dfc7ab4