### PR TITLE
Add two-pass occlusion culling with depth pyramid

### DIFF
--- a/mjolnir/shader/occlusion_culling/cull.comp
+++ b/mjolnir/shader/occlusion_culling/cull.comp
@@ -79,13 +79,17 @@ layout(set = 0, binding = 5) buffer DrawCommandBuffer {
     DrawCommand commands[];
 };
 
-// Visibility tracking - stores if object was visible last frame
-layout(set = 0, binding = 6) buffer VisibilityBuffer {
-    uint visibility[];  // Bitfield: 1 = was visible last frame
+// Visibility history and write-back buffers
+layout(set = 0, binding = 6) readonly buffer VisibilityHistory {
+    uint visibility_history[];
+};
+
+layout(set = 0, binding = 7) buffer VisibilityBuffer {
+    uint visibility_current[];
 };
 
 // Depth pyramid for occlusion testing (late pass only)
-layout(set = 0, binding = 7) uniform sampler2D depthPyramid;
+layout(set = 0, binding = 8) uniform sampler2D depthPyramid;
 
 // Frustum culling test
 bool frustumCull(Camera camera, vec3 worldCenter, vec3 worldExtent) {
@@ -197,25 +201,13 @@ void main() {
         return;
     }
     
-    // Check visibility from last frame
     uint visIndex = node_id / 32u;
     uint visBit = node_id % 32u;
-    bool wasVisibleLastFrame = (visibility[visIndex] & (1u << visBit)) != 0u;
-    
-    // Two-phase culling strategy (like Niagara):
-    // EARLY pass (culling_mode == 0): Only render objects visible last frame
-    // LATE pass (culling_mode == 1): Render objects NOT visible last frame with occlusion culling
-    
-    if (params.culling_mode == 0u) {
-        // Early pass - skip if not visible last frame
-        if (!wasVisibleLastFrame) {
-            return;
-        }
-    } else {
-        // Late pass - skip if already rendered in early pass
-        if (wasVisibleLastFrame) {
-            return;
-        }
+    bool wasVisibleLastFrame = (visibility_history[visIndex] & (1u << visBit)) != 0u;
+
+    // Early pass renders the previous frame's visible set to bootstrap depth
+    if (params.culling_mode == 0u && !wasVisibleLastFrame) {
+        return;
     }
     
     bool visible = true;
@@ -251,9 +243,9 @@ void main() {
         }
     }
     
-    // Update visibility for next frame
-    if (visible) {
-        atomicOr(visibility[visIndex], 1u << visBit);
+    // Update visibility for next frame (late pass only)
+    if (visible && params.culling_mode == 1u) {
+        atomicOr(visibility_current[visIndex], 1u << visBit);
     }
     
     if (!visible) {

--- a/mjolnir/world/world.odin
+++ b/mjolnir/world/world.odin
@@ -430,6 +430,48 @@ dispatch_visibility :: proc(
   )
 }
 
+dispatch_visibility_with_occlusion :: proc(
+  world: ^World,
+  gpu_context: ^gpu.GPUContext,
+  resources_manager: ^resources.Manager,
+  command_buffer: vk.CommandBuffer,
+  frame_index: u32,
+  category: VisibilityCategory,
+  request: VisibilityRequest,
+  depth_pyramid: ^DepthPyramid,
+  early_pass: bool,
+) -> VisibilityResult {
+  return visibility_system_dispatch_with_occlusion(
+    &world.visibility,
+    gpu_context,
+    resources_manager,
+    command_buffer,
+    frame_index,
+    category,
+    request,
+    depth_pyramid,
+    early_pass,
+  )
+}
+
+ensure_depth_pyramid :: proc(
+  world: ^World,
+  gpu_context: ^gpu.GPUContext,
+  width, height: u32,
+) -> vk.Result {
+  return depth_pyramid_ensure_size(&world.depth_pyramid, gpu_context, width, height)
+}
+
+generate_depth_pyramid :: proc(
+  world: ^World,
+  gpu_context: ^gpu.GPUContext,
+  command_buffer: vk.CommandBuffer,
+  depth_view: vk.ImageView,
+  width, height: u32,
+) {
+  depth_pyramid_generate(&world.depth_pyramid, gpu_context, command_buffer, depth_view, width, height)
+}
+
 despawn :: proc(world: ^World, handle: resources.Handle) -> bool {
   node := resources.get(world.nodes, handle)
   if node == nil {


### PR DESCRIPTION
## Summary
- implement visibility history buffers and shader changes so the occlusion pass produces next-frame visibility while supporting early depth-only draws
- add runtime resizing for the depth pyramid and copy the current visibility bitset into history after the occlusion pass completes
- drive the geometry pass through early depth pre-pass, depth pyramid generation, and the occlusion-driven draw list for the main render

## Testing
- make check

------
https://chatgpt.com/codex/tasks/task_e_68e2246232d8833094dbb60a6461a005