### PR TITLE
Refine occlusion culling with hierarchical depth checks

### DIFF
--- a/mjolnir/render/occlusion/occlusion.odin
+++ b/mjolnir/render/occlusion/occlusion.odin
@@ -215,8 +215,8 @@ init :: proc(
   // Create sampler used for manual min reduction in the compute shader
   sampler_info := vk.SamplerCreateInfo {
     sType                   = .SAMPLER_CREATE_INFO,
-    magFilter               = .LINEAR,
-    minFilter               = .LINEAR,
+    magFilter               = .NEAREST,
+    minFilter               = .NEAREST,
     mipmapMode              = .NEAREST,
     addressModeU            = .CLAMP_TO_EDGE,
     addressModeV            = .CLAMP_TO_EDGE,

--- a/mjolnir/shader/occlusion_cull/compute.comp
+++ b/mjolnir/shader/occlusion_cull/compute.comp
@@ -170,20 +170,38 @@ void main() {
     }
     float mipLevel = clamp(log2(maxDimension), 0.0, maxAvailableLevel);
 
-    float objectDepth = 0.0;
-
     vec3 nearPointView = viewCenter - viewDir * radius;
-    vec4 clipNear = camera.projection * vec4(nearPointView, 1.0);
-    if (clipNear.w <= 0.0) {
+
+    if (nearPointView.z >= -params.znear) {
         visibilityCurr[nodeIndex] = 1u;
         return;
     }
 
-    objectDepth = clipNear.z / clipNear.w;
-    objectDepth = objectDepth * 0.5 + 0.5;
-    objectDepth = clamp(objectDepth, 0.0, 1.0);
+    float objectDepth = 1.0;
+    bool depthValid = false;
 
-    if (nearPointView.z >= -params.znear) {
+    vec3 depthOffsets[6] = vec3[](
+        vec3(0.0),
+        right * radius,
+        -right * radius,
+        up * radius,
+        -up * radius,
+        -viewDir * radius
+    );
+
+    for (int i = 0; i < 6; ++i) {
+        vec4 clip = camera.projection * vec4(viewCenter + depthOffsets[i], 1.0);
+        if (clip.w <= 0.0) {
+            continue;
+        }
+        float depth = clip.z / clip.w;
+        depth = depth * 0.5 + 0.5;
+        depth = clamp(depth, 0.0, 1.0);
+        objectDepth = min(objectDepth, depth);
+        depthValid = true;
+    }
+
+    if (!depthValid) {
         visibilityCurr[nodeIndex] = 1u;
         return;
     }
@@ -209,11 +227,21 @@ void main() {
         vec2 uvUpperLeft = vec2(expandedMin.x, expandedMax.y);
 
         float minDepth = 1.0;
-        minDepth = min(minDepth, textureLod(depthPyramid, uvCenter, levelFloat).x);
-        minDepth = min(minDepth, textureLod(depthPyramid, expandedMin, levelFloat).x);
-        minDepth = min(minDepth, textureLod(depthPyramid, uvUpperLeft, levelFloat).x);
-        minDepth = min(minDepth, textureLod(depthPyramid, uvLowerRight, levelFloat).x);
-        minDepth = min(minDepth, textureLod(depthPyramid, expandedMax, levelFloat).x);
+        vec2 samples[9] = vec2[](
+            uvCenter,
+            expandedMin,
+            expandedMax,
+            uvUpperLeft,
+            uvLowerRight,
+            vec2(expandedMin.x, uvCenter.y),
+            vec2(expandedMax.x, uvCenter.y),
+            vec2(uvCenter.x, expandedMin.y),
+            vec2(uvCenter.x, expandedMax.y)
+        );
+
+        for (int i = 0; i < 9; ++i) {
+            minDepth = min(minDepth, textureLod(depthPyramid, samples[i], levelFloat).x);
+        }
 
         if (minDepth <= 1e-5) {
             visibleResult = true;

--- a/mjolnir/shader/occlusion_cull/compute.comp
+++ b/mjolnir/shader/occlusion_cull/compute.comp
@@ -150,22 +150,27 @@ void main() {
     ndcMin = clamp(ndcMin, vec2(-1.0), vec2(1.0));
     ndcMax = clamp(ndcMax, vec2(-1.0), vec2(1.0));
 
+    vec2 pyramidDim = vec2(params.pyramidWidth, params.pyramidHeight);
+    if (pyramidDim.x <= 0.0 || pyramidDim.y <= 0.0) {
+        visibilityCurr[nodeIndex] = 1u;
+        return;
+    }
+
     vec2 uvMin = ndcMin * 0.5 + 0.5;
     vec2 uvMax = ndcMax * 0.5 + 0.5;
     vec2 uvSize = max(uvMax - uvMin, vec2(0.0));
 
-    float pixelWidth = uvSize.x * params.pyramidWidth;
-    float pixelHeight = uvSize.y * params.pyramidHeight;
+    float pixelWidth = uvSize.x * pyramidDim.x;
+    float pixelHeight = uvSize.y * pyramidDim.y;
     float maxDimension = max(max(pixelWidth, pixelHeight), 1.0);
-    float pyramidMaxDim = max(params.pyramidWidth, params.pyramidHeight);
+    float pyramidMaxDim = max(pyramidDim.x, pyramidDim.y);
     float maxAvailableLevel = 0.0;
     if (pyramidMaxDim > 0.0) {
         maxAvailableLevel = log2(pyramidMaxDim);
     }
     float mipLevel = clamp(log2(maxDimension), 0.0, maxAvailableLevel);
 
-    vec2 uvCenter = (uvMin + uvMax) * 0.5;
-    float minDepth = textureLod(depthPyramid, uvCenter, mipLevel).x;
+    float objectDepth = 0.0;
 
     vec3 nearPointView = viewCenter - viewDir * radius;
     vec4 clipNear = camera.projection * vec4(nearPointView, 1.0);
@@ -174,7 +179,8 @@ void main() {
         return;
     }
 
-    float objectDepth = clipNear.z / clipNear.w;
+    objectDepth = clipNear.z / clipNear.w;
+    objectDepth = objectDepth * 0.5 + 0.5;
     objectDepth = clamp(objectDepth, 0.0, 1.0);
 
     if (nearPointView.z >= -params.znear) {
@@ -182,13 +188,45 @@ void main() {
         return;
     }
 
-    if (minDepth <= 1e-5) {
-        visibilityCurr[nodeIndex] = 1u;
-        return;
+    const float depthBias = 1e-2;
+
+    int startLevel = int(floor(mipLevel + 0.5));
+    if (startLevel < 0) {
+        startLevel = 0;
     }
 
-    const float depthBias = 1e-2;
-    visible = objectDepth <= minDepth + depthBias;
+    bool visibleResult = true;
 
-    visibilityCurr[nodeIndex] = visible ? 1u : 0u;
+    for (int level = startLevel; level >= 0; --level) {
+        float levelFloat = float(level);
+        float levelScale = exp2(levelFloat);
+        vec2 texelSize = levelScale / pyramidDim;
+        vec2 expandedMin = clamp(uvMin - texelSize, vec2(0.0), vec2(1.0));
+        vec2 expandedMax = clamp(uvMax + texelSize, vec2(0.0), vec2(1.0));
+
+        vec2 uvCenter = (expandedMin + expandedMax) * 0.5;
+        vec2 uvLowerRight = vec2(expandedMax.x, expandedMin.y);
+        vec2 uvUpperLeft = vec2(expandedMin.x, expandedMax.y);
+
+        float minDepth = 1.0;
+        minDepth = min(minDepth, textureLod(depthPyramid, uvCenter, levelFloat).x);
+        minDepth = min(minDepth, textureLod(depthPyramid, expandedMin, levelFloat).x);
+        minDepth = min(minDepth, textureLod(depthPyramid, uvUpperLeft, levelFloat).x);
+        minDepth = min(minDepth, textureLod(depthPyramid, uvLowerRight, levelFloat).x);
+        minDepth = min(minDepth, textureLod(depthPyramid, expandedMax, levelFloat).x);
+
+        if (minDepth <= 1e-5) {
+            visibleResult = true;
+            break;
+        }
+
+        if (objectDepth <= minDepth + depthBias) {
+            visibleResult = true;
+            break;
+        }
+
+        visibleResult = false;
+    }
+
+    visibilityCurr[nodeIndex] = visibleResult ? 1u : 0u;
 }


### PR DESCRIPTION
## Summary
- reproject occlusion test depth into [0,1] clip space before comparison
- iterate down the depth pyramid to refine tests with higher resolution levels before culling objects

## Testing
- make check

------
https://chatgpt.com/codex/tasks/task_e_68e5b3d119108330901a19b552298b9a